### PR TITLE
Fix namespace `sphinxcontrib` to be usable with `zc.buildout`.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,11 @@
 Here you can see the list of changes between each 'sphinxcontrib-openapi'
 release.
 
+0.8.4 (unreleased)
+=================
+
+- Fix namespace ``sphinxcontrib`` to be usable with ``zc.buildout``.
+
 0.8.3 (2023-10-24)
 =================
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,5 @@ setup(
         "Framework :: Sphinx",
         "Framework :: Sphinx :: Extension",
     ],
-    namespace_packages=["sphinxcontrib"],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
Without this change `zc.buildout` creates a placeholder `__init__.py` in `sphinxcontrib` containing a `pkg_resources` namespace declaration. This breaks using other packages of the same namespace which already use the native (implicit) namespace.